### PR TITLE
Add a chat() function to test from the browser console

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -230,6 +230,9 @@ export function setup() {
     pollState = { ...DEBUG_POLL_STATE };
     renderInitial(pollState);
     renderUpdate(pollState);
+    window.chat = (message, username = "testuser", mod = true) => {
+      return pollState = handleMessage({ mod, username }, message, pollState)
+    }
   } else {
     pollState = { ...INITIAL_POLL_STATE };
   }


### PR DESCRIPTION
This allows simulating chat messages from the browser dev tools, without using actual Twitch chat.

Use chat("!poll") to send a message by 'testuser', who is a mod. Use chat("2 two-hoo", "chad", false)  to send a message as a regular (non-mod) user named 'chad'.

The return value of chat(...) is the new poll state, for inspection in the console.