### PR TITLE
Compute option text color based on custom properties

### DIFF
--- a/src/components/PollOption.vue
+++ b/src/components/PollOption.vue
@@ -5,10 +5,7 @@
     :key="optionNumber"
   >
     <div>
-      <div
-        class="option-number"
-        ref="optionNumber"
-      >
+      <div class="option-number">
         {{ optionNumber }}
       </div>
       <span :contentEditable="true">{{ optionName }}</span
@@ -37,44 +34,55 @@ export default {
     totalCount: Number,
     winningOptions: Array,
   },
-  mounted() {
-    this.setContrastingTextColor();
-  },
-  updated() {
-    this.setContrastingTextColor();
-  },
-  methods: {
-    setContrastingTextColor() {
-      this.$nextTick(() => {
-        console.log('TESERTJseroisjerosjerojseorjseojr');
-        const element = this.$refs.optionNumber;
-        const backgroundColor = getComputedStyle(element).backgroundColor;
-
-        const toWhiteContrast = colord(backgroundColor).contrast('#ffffff');
-        const toBlackContrast = colord(backgroundColor).contrast('#000000');
-
-        if (toWhiteContrast > toBlackContrast) {
-          element.style.color = '#ffffff';
-        } else {
-          element.style.color = '#000000';
-        }
-      });
-    },
-  },
   computed: {
     percentage() {
       return this.totalCount === 0 ? 0 : Math.round((this.voteCount / this.totalCount) * 100);
     },
-    optionClasses() {
+    /**
+     * @returns {'win'|'draw'|''} a text representation of the status of this option
+     */
+    optionStatus() {
       if (this.winningOptions.includes(this.optionNumber)) {
         if (this.winningOptions.length === 1) {
-          return 'win-option animate__animated animate__bounceIn';
+          return 'win';
         } else {
-          return 'draw-option animate__animated animate__shakeX';
+          return 'draw';
         }
       }
-
       return '';
+    },
+    optionClasses() {
+      switch (this.optionStatus) {
+        case 'win':
+          return 'win-option animate__animated animate__bounceIn';
+        case 'draw':
+          return 'draw-option animate__animated animate__shakeX';
+        default:
+          return '';
+      }
+    },
+    optionBackground() {
+      // the interesting custom properties should exist on :root (and thus the body)
+      const style = getComputedStyle(document.body);
+      switch (this.optionStatus) {
+        case 'win':
+          return style.getPropertyValue('--option-color-win');
+        case 'draw':
+          return style.getPropertyValue('--option-color-draw');
+        default:
+          return style.getPropertyValue('--option-color');
+      }
+    },
+    contrastingTextColor() {
+      const backgroundColor = this.optionBackground;
+      const toWhiteContrast = colord(backgroundColor).contrast('#ffffff');
+      const toBlackContrast = colord(backgroundColor).contrast('#000000');
+
+      if (toWhiteContrast > toBlackContrast) {
+        return '#fff';
+      } else {
+        return '#000';
+      }
     },
   },
 };
@@ -87,6 +95,7 @@ export default {
 
 .option-number {
   background-color: var(--option-color);
+  color: v-bind(contrastingTextColor);
   width: 40px;
   height: 40px;
   text-align: center;


### PR DESCRIPTION
Zur Diskussion habe ich mal eine alternative Variante gebaut, die die kontrastreiche Textfarbe anders bestimmt/setzt. Die finde ich etwas "vue-iger" als den bisherigen Ansatz. 

Anders als ich gehofft hatte, ist mir aber keine super-dynamische Lösung wie ein `useComputedStyle()` über den Weg gelaufen, die einem erspart hätte, das Wissen über die relevanten Custom Properties aus den Styles nochmal in JS zu doppeln.

Compute option text color based on custom properties

The previous approach looked at the computed styles of the rendered
option. This naturally required an initial render before the proper
contrasting text color could be determined. This approach also
"manually" set the color as inline style on the DOM element.

This commit uses a different approach, looking directly at the relevant
option background custom properties for the various option statuses
(running/lost, draw, win). This way we can determine the current
background color before rendering the option. We can determine the
correct text color during the initial render and don't have to hook into
the render lifecycle.

We now set the text color using dynamic CSS binding in the style block
via v-bind(...). This way the color has less specificity than the inline
style approach and can be more easily overridden in custom CSS
if desired.

Extracting a new optionStatus() computed property, to use this for
determinining the option classes as well as the new code getting the
relevant 'option background' custom property.