### PR TITLE
Build und publish the generated static files as a branch on GitHub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: Release a new version
+
+# triggered manually
+on: 
+  workflow_dispatch:
+    inputs:
+      releaseVersion:
+        description: 'Release Version (e.g. 4.2)'     
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build -- --config vite.github-config.js
+      - name: Uploading static Vite-generated artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: vite-artifacts
+          path: build
+
+  release-to-branch:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      # as per https://github.com/marketplace/actions/git-auto-commit
+      # Give the default GITHUB_TOKEN write permission to commit and push the
+      # added or changed files to the repository.
+      contents: write
+
+    steps:
+      - run: echo "Creating release ${{ github.event.inputs.releaseVersion }}"
+      - uses: actions/checkout@v3
+      - name: Using Vite-generated artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: vite-artifacts
+          path: release
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: Add generated files for release ${{ github.event.inputs.releaseVersion }}
+          branch: release/${{ github.event.inputs.releaseVersion }}
+          create_branch: true

--- a/vite.github-config.js
+++ b/vite.github-config.js
@@ -1,0 +1,21 @@
+import { fileURLToPath, URL } from 'node:url';
+
+import defaultConfig from './vite.config.js';
+import { mergeConfig } from 'vite';
+
+// https://vitejs.dev/config/
+export default mergeConfig(
+  defaultConfig,
+  {
+    build: {
+      lib: {
+        entry: fileURLToPath(new URL('./src/main.js', import.meta.url)),
+        fileName: 'poll',
+        formats: ['es'],
+      },
+    },
+    // as per the 'Environment Variables' box on https://vitejs.dev/guide/build#library-mode
+    define: { 'process.env.NODE_ENV': '"production"' },
+  },
+  true,
+);


### PR DESCRIPTION
Adding a manual GitHub workflow to create a new release from the 'main' branch. Creates a release/... branch with the static files generated by Vite. This way we can serve them through a CDN.

We adapt the Vite/Roillup config to not use hashes in the generated file names, so the file name is fixed and does not change between versions.