### PR TITLE
Fix tests on Node 16

### DIFF
--- a/test/rendering.test.js
+++ b/test/rendering.test.js
@@ -25,6 +25,15 @@ const INITIAL_POLL_STATE = {
   userVotes: {},
 };
 
+//FIXME: this is a specific polyfill until we don't need Node 16 support (without native structuredClone) anymore
+window.structuredClone = window.structuredClone || function (o) {
+  return {
+    ...o,
+    options: { ...o.options },
+    userVotes: { ...o.userVotes },
+  };
+};
+
 const pollWrapper = mount(App, {
   attachTo: 'body', // 'attachTo' is necessary for isVisible() to work properly
 });


### PR DESCRIPTION
Adding a specific structuredClone() for the store on Node 16. Node 16 has no native structuredClone() and the tests failed due to this.

We could currently actually do without cloning at all, because we don't seem to re-use initial state across tests.
However, not deeply cloning options/userVotes will share this state between test runs using the same initial state. This might otherwise bite us in the future.